### PR TITLE
Add comment status (approved, waiting or spam) to responded json

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -589,7 +589,13 @@ class Restful_Action extends Typecho_Widget implements Widget_Interface_Do
             }
         }
 
-        $this->throwData(null);
+        $query = $this->db->select('coid', 'status')
+            ->from('table.comments')
+            ->where('text = ?', $text)
+            ->order('created', Typecho_Db::SORT_DESC);
+        $res = $this->db->fetchRow($query);
+
+        $this->throwData($res);
     }
 
     /**

--- a/Plugin.php
+++ b/Plugin.php
@@ -7,7 +7,7 @@ if (!defined('__TYPECHO_ROOT_DIR__')) {
  *
  * @package Restful
  * @author MoeFront Studio
- * @version 1.0.0
+ * @version 1.1.0
  * @link https://moefront.github.io
  */
 class Restful_Plugin implements Typecho_Plugin_Interface


### PR DESCRIPTION
# Before: 
POST /api/comment will returns:
```json
{
    "status": "success",
    "message":  "",
    "data": null
}
```
# After:
```json
{
    "status": "success",
    "message": "",
    "data": {
        "coid": 76,
        "status": "waiting"
    }
}
```

Happy Valentines‘s day (